### PR TITLE
为归档、分类、标签页面添加分页功能

### DIFF
--- a/blog/views.py
+++ b/blog/views.py
@@ -260,11 +260,8 @@ def archives(request, year, month):
     return render(request, 'blog/index.html', context={'post_list': post_list})
 
 
-class ArchivesView(ListView):
-    model = Post
-    template_name = 'blog/index.html'
-    context_object_name = 'post_list'
-
+# 归档页面，继承IndexView，可以拥有分页功能，减少代码量
+class ArchivesView(IndexView):
     def get_queryset(self):
         year = self.kwargs.get('year')
         month = self.kwargs.get('month')
@@ -279,21 +276,15 @@ def category(request, pk):
     return render(request, 'blog/index.html', context={'post_list': post_list})
 
 
-class CategoryView(ListView):
-    model = Post
-    template_name = 'blog/index.html'
-    context_object_name = 'post_list'
-
+# 分类页面，继承IndexView
+class CategoryView(IndexView):
     def get_queryset(self):
         cate = get_object_or_404(Category, pk=self.kwargs.get('pk'))
         return super(CategoryView, self).get_queryset().filter(category=cate)
 
 
-class TagView(ListView):
-    model = Post
-    template_name = 'blog/index.html'
-    context_object_name = 'post_list'
-
+# 标签页面，继承自IndexView
+class TagView(IndexView):
     def get_queryset(self):
         tag = get_object_or_404(Tag, pk=self.kwargs.get('pk'))
         return super(TagView, self).get_queryset().filter(tags=tag)

--- a/templates/blog/index.html
+++ b/templates/blog/index.html
@@ -50,33 +50,46 @@
     {% comment %}
     完善的分页导航
     {% endcomment %}
-    {% if is_paginated %}
         <div class="pagination">
             <ul>
-                {% if first %}
-                    <li><a href="?page=1">1</a></li>
+                {% if not is_paginated %}
+                    <a href="?page=1">首页</a>
+                    <a href="?page=1" style="color: red">1</a>
+                    <a href="?page=1">尾页</a>
                 {% endif %}
-                {% if left %}
-                    {% if left_has_more %}
-                        <li><span>...</span></li>
+                {% if is_paginated %}
+                    <a href="?page=1">首页</a>
+                    {% if page_obj.has_previous %}
+                        <a href="?page={{ page_obj.previous_page_number }}">上一页</a>
                     {% endif %}
-                    {% for i in left %}
-                        <li><a href="?page={{ i }}">{{ i }}</a></li>
-                    {% endfor %}
-                {% endif %}
-                <li class="current"><a href="?page={{ page_obj.number }}">{{ page_obj.number }}</a></li>
-                {% if right %}
-                    {% for i in right %}
-                        <li><a href="?page={{ i }}">{{ i }}</a></li>
-                    {% endfor %}
-                    {% if right_has_more %}
-                        <li><span>...</span></li>
+                    {% if first %}
+                        <li><a href="?page=1">1</a></li>
                     {% endif %}
-                {% endif %}
-                {% if last %}
-                    <li><a href="?page={{ paginator.num_pages }}">{{ paginator.num_pages }}</a></li>
+                    {% if left %}
+                        {% if left_has_more %}
+                            <li><span>...</span></li>
+                        {% endif %}
+                        {% for i in left %}
+                            <li><a href="?page={{ i }}">{{ i }}</a></li>
+                        {% endfor %}
+                    {% endif %}
+                    <li class="current"><a href="?page={{ page_obj.number }}" style="color: red">{{ page_obj.number }}</a></li>
+                    {% if right %}
+                        {% for i in right %}
+                            <li><a href="?page={{ i }}">{{ i }}</a></li>
+                        {% endfor %}
+                        {% if right_has_more %}
+                            <li><span>...</span></li>
+                        {% endif %}
+                    {% endif %}
+                    {% if last %}
+                        <li><a href="?page={{ paginator.num_pages }}">{{ paginator.num_pages }}</a></li>
+                    {% endif %}
+                    {% if page_obj.has_next %}
+                        <a href="?page={{ page_obj.next_page_number }}">下一页</a>
+                    {% endif %}
+                    <a href="?page={{ paginator.num_pages }}">尾页</a>
                 {% endif %}
             </ul>
         </div>
-    {% endif %}
 {% endblock main %}


### PR DESCRIPTION
- 对blog/views文件的调整
使用类的继承属性，在blog/views中归档（ArchiveView）、分类（CategoryView）、标签（TagView）类继承主页（IndexView），使其具备分页功能

- 对templates/index.html调整
修改了index.html中的分页导航，结合“简单的分页导航”和“完善的分页导航”，完成以下功能：

1.始终显示“首页” “尾页”

2.自动判断是否显示“上一页” “下一页” 

 3.在不可分页的情况下，显示“1”